### PR TITLE
[feat] change Confluence storage to allow markdown persisting

### DIFF
--- a/lib/release_notes_bot/persists.ex
+++ b/lib/release_notes_bot/persists.ex
@@ -68,8 +68,8 @@ defmodule ReleaseNotesBot.Persists do
       ],
       body: %{
         storage: %{
-          value: "<p>#{page_text}</p>",
-          representation: "storage"
+          value: page_text,
+          representation: "wiki"
         }
       }
     }


### PR DESCRIPTION
Changes storage medium in Confluence to allow for basic markdown syntax.