### PR TITLE
MRNN4 - Include Confluence link in Slack message 

### DIFF
--- a/lib/release_notes_bot/persists.ex
+++ b/lib/release_notes_bot/persists.ex
@@ -19,6 +19,10 @@ defmodule ReleaseNotesBot.Persists do
     parent_id = space_parent_id
     user = Application.get_env(:release_notes_bot, :confluence_email)
     apikey = Application.get_env(:release_notes_bot, :confluence_api_key)
+    organization = "mojotech"
+    endpoint_url = "https://#{organization}.atlassian.net/wiki/"
+    endpoint_persistence = endpoint_url <> "rest/api/content"
+    endpoint_source = endpoint_url <> "spaces/#{space_key}/pages/#{parent_id}/#{title}"
     token = Base.encode64("#{user}:#{apikey}")
     release = Earmark.as_html!(release, %Earmark.Options{compact_output: true})
 
@@ -29,6 +33,10 @@ defmodule ReleaseNotesBot.Persists do
         :space_id => "#{space_id}",
         :space_key => "#{space_key}",
         :parent_id => "#{parent_id}",
+        :organization => "#{organization}",
+        :endpoint_url => "#{endpoint_url}",
+        :endpoint_persistence => "#{endpoint_persistence}",
+        :endpoint_source => "#{endpoint_source}",
         :token => "#{token}"
       })
 
@@ -39,7 +47,7 @@ defmodule ReleaseNotesBot.Persists do
       case Finch.request(
              Finch.build(
                :post,
-               "https://mojotech.atlassian.net/wiki/rest/api/content",
+               endpoint_persistence,
                headers,
                Jason.encode!(body)
              ),

--- a/lib/release_notes_bot/persists.ex
+++ b/lib/release_notes_bot/persists.ex
@@ -53,14 +53,14 @@ defmodule ReleaseNotesBot.Persists do
              ),
              ReleaseNotesBot.Finch
            ) do
-        {:ok, response} ->
-          response.status
+        {:ok, _response} ->
+          {:ok, endpoint_source}
 
         {:error, _reason} ->
-          500
+          {:error, 500}
       end
     else
-      400
+      {:error, 400}
     end
   end
 

--- a/lib/release_notes_bot/projects.ex
+++ b/lib/release_notes_bot/projects.ex
@@ -92,7 +92,7 @@ defmodule ReleaseNotesBot.Projects do
           Map.put_new(
             details,
             :persistence_status,
-            Persists.persist(details.title, details.message)
+            details.title |> Persists.persist(details.message) |> interpret_status
           )
 
         Note.create(%{
@@ -119,6 +119,16 @@ defmodule ReleaseNotesBot.Projects do
 
   def parse_params(params = %{}) do
     params
+  end
+
+  defp interpret_status(result) do
+    case result do
+      {:ok, _} ->
+        200
+
+      {:error, status} ->
+        status
+    end
   end
 
   defp interpret_persisted(status) do

--- a/lib/release_notes_bot/schema/persist.ex
+++ b/lib/release_notes_bot/schema/persist.ex
@@ -12,12 +12,38 @@ defmodule ReleaseNotesBot.Schema.Persist do
     field(:space_id, :string)
     field(:space_key, :string)
     field(:parent_id, :string)
+    field(:organization, :string)
+    field(:endpoint_url, :string)
+    field(:endpoint_persistence, :string)
+    field(:endpoint_source, :string)
     field(:token, :string)
   end
 
   def changeset(persist, params) do
     persist
-    |> cast(params, [:title, :message, :space_id, :space_key, :parent_id, :token])
-    |> validate_required([:title, :message, :space_id, :space_key, :parent_id, :token])
+    |> cast(params, [
+      :title,
+      :message,
+      :space_id,
+      :space_key,
+      :parent_id,
+      :token,
+      :endpoint_url,
+      :endpoint_persistence,
+      :endpoint_source,
+      :organization
+    ])
+    |> validate_required([
+      :title,
+      :message,
+      :space_id,
+      :space_key,
+      :parent_id,
+      :token,
+      :endpoint_url,
+      :endpoint_persistence,
+      :endpoint_source,
+      :organization
+    ])
   end
 end

--- a/lib/release_notes_bot_web/controllers/webhook_controller.ex
+++ b/lib/release_notes_bot_web/controllers/webhook_controller.ex
@@ -87,10 +87,12 @@ defmodule ReleaseNotesBotWeb.WebhookController do
     # Persist to persistence provider
     if action in @persist_actions do
       if match_url == @source_adv_repo_url do
-        Persists.persist(release["name"], release["body"], @source_adv_confluence)
+        Persists.persist(build_persistence_title(release), release["body"], @source_adv_confluence)
       else
-        Persists.persist(release["name"], release["body"])
+        Persists.persist(build_persistence_title(release), release["body"])
       end
     end
   end
+
+  defp build_persistence_title(release), do: release["name"]
 end


### PR DESCRIPTION
This PR refactors the webhook_controller.process_release/1 function to accept a refactored response with a confluence persistence location from persists.persist/3. A couple small helper functions were appended to persists to help with parsing the correct url. process_release/1 takes the returned url on a release publish event and appends it as an embedded link to the slack message that it triggers.
<img width="186" alt="image" src="https://user-images.githubusercontent.com/102161624/191784133-b425cdba-7e71-44c2-a8c5-c3fd85e60210.png">

This PR will fail CI until PR 27 is changed or is based from a different PR. Adding DO NOT MERGE until this is resolved.