### PR TITLE
[fix] ignore release edits

### DIFF
--- a/lib/release_notes_bot_web/controllers/webhook_controller.ex
+++ b/lib/release_notes_bot_web/controllers/webhook_controller.ex
@@ -5,7 +5,7 @@ defmodule ReleaseNotesBotWeb.WebhookController do
   use ReleaseNotesBotWeb, :controller
   alias ReleaseNotesBot.{Projects, WebhookEvents, Repositories, Clients, Channels, Persists}
 
-  @release_actions ["published", "edited", "deleted"]
+  @release_actions ["published", "deleted"]
   @persist_actions ["published"]
   @source_adv_repo_url "https://github.com/mojotech/source_advisors"
   @source_adv_confluence 48_070_657


### PR DESCRIPTION
As it stands right now, edits to drafts count as regular edits so those drafts will persist. We need to change this. A new ticket will be made to track release tag history. But for now, we will ignore edits since they serve no value currently.