### PR TITLE
Add repository webhook addition url in new project Slack response

### DIFF
--- a/lib/release_notes_bot/projects.ex
+++ b/lib/release_notes_bot/projects.ex
@@ -70,7 +70,8 @@ defmodule ReleaseNotesBot.Projects do
       ProjectProviders.create(%{"project_id" => new_project.id})
     end
 
-    Repositories.find_or_create_by_slack(new_project.id, repo_input["repo-url-input"]["value"])
+    github_repo_url =
+      Repositories.find_or_create_by_slack(new_project.id, repo_input["repo-url-input"]["value"])
 
     %{
       client: client,

--- a/lib/release_notes_bot/projects.ex
+++ b/lib/release_notes_bot/projects.ex
@@ -76,7 +76,8 @@ defmodule ReleaseNotesBot.Projects do
     %{
       client: client,
       project: project_name,
-      peristence: provider_input["project-provider-input"]["value"]
+      peristence: provider_input["project-provider-input"]["value"],
+      add_webhook: github_repo_url
     }
   end
 

--- a/lib/release_notes_bot/repositories.ex
+++ b/lib/release_notes_bot/repositories.ex
@@ -58,11 +58,15 @@ defmodule ReleaseNotesBot.Repositories do
           project_id: project_id
         })
 
+        repo_url <> "/settings/hooks/new"
+
       # Check if repo exists given its url
       _ ->
         Repositories.update(repo, %{
           project_id: project_id
         })
+
+        nil
     end
   end
 end

--- a/lib/release_notes_bot_web/controllers/slack_interaction_controller.ex
+++ b/lib/release_notes_bot_web/controllers/slack_interaction_controller.ex
@@ -16,11 +16,11 @@ defmodule ReleaseNotesBotWeb.SlackInteractionController do
           "#{user["name"]} has configured this channel to accept messages and updates for projects under: #{client_name}"
         )
 
-      %{client: client, project: project_name, peristence: url} ->
+      %{client: client, project: project_name, peristence: url, add_webhook: webhook} ->
         Channels.post_message_all_client_channels(
           client,
           "#{user["name"]} has created a new project under #{client.name} titled: '#{project_name}'. Release notes will be persisted to " <>
-            where_to_persist(url)
+            where_to_persist(url) <> determine_serve_repo_webhook_url(webhook)
         )
 
       %{details: details, client: client} when client.channels != nil ->
@@ -48,6 +48,13 @@ defmodule ReleaseNotesBotWeb.SlackInteractionController do
     case url do
       nil -> "the default location."
       _ -> "<#{url}|this specified location>."
+    end
+  end
+
+  defp determine_serve_repo_webhook_url(webhook) do
+    case webhook do
+      nil -> ""
+      _ -> ". Click <#{webhook}|this link> to add a webhook to your repository."
     end
   end
 end


### PR DESCRIPTION
Adding DO NOT MERGE because this branch is too far removed from main.

When a new project is created, this PR will post to the user the direct url to add a webhook if one has not been added yet. 