### PR TITLE
[chore] add .tool-versions to .gitignore for asdf users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ npm-debug.log
 
 # the used fly.io config
 fly.toml
+
+# asdf config - it is not needed anymore
+.tool-versions

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: postgres
         POSTGRES_HOSTNAME: db
-        POSTGRES_HOST_AUTH_METHOD: trust
   app:
     build:
       dockerfile: ./docker/dev/Dockerfile
@@ -20,8 +19,6 @@ services:
     environment:
         MIX_ENV: dev
         SECRET_KEY_BASE: secret
-        DATABASE_URL: postgres://postgres:password@db/release_notes
-        PORT: 4002
     ports:
       - "4002:4002"
     volumes:

--- a/script/format
+++ b/script/format
@@ -1,0 +1,3 @@
+#/bin/bash
+docker-compose run app mix credo -a
+docker-compose run app mix format


### PR DESCRIPTION
As an asdf user, I can no longer run `mix format` or `mix credo -a` since `.tool-versions` was removed in #41. I think adding `.tool-versions` to `.gitignore` will be a benefit so that way `asdf` is not required. 

Alternatively, we could just add `.tool-versions` back into version control.

Alternatively, we could create a bash script to execute something like `docker-compose web mix format` and equivalent for credo.