### PR TITLE
automate db dumps

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -8,6 +8,15 @@ RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y apt-utils
 RUN apt-get install -y build-essential
 RUN apt-get install -y inotify-tools
+RUN apt-get install -y gpg
+RUN apt-get install -y curl
+RUN apt-get install -y apt-transport-https
+
+# Postgres 14 for pg_dump util
+RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main" | tee /etc/apt/sources.list.d/postgresql.list
+RUN apt update -y
+RUN apt install -y postgresql-14
 
 # Phoenix
 RUN mix local.hex --force

--- a/mix.exs
+++ b/mix.exs
@@ -68,6 +68,8 @@ defmodule ReleaseNotesBot.MixProject do
       setup: ["deps.get", "ecto.setup"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
+      "db.migrate": ["ecto.migrate", "ecto.dump"],
+      "db.rollback": ["ecto.rollback", "ecto.dump"],
       test: ["ecto.create --quiet", "ecto.migrate --quiet", "test"],
       "assets.deploy": ["esbuild default --minify", "phx.digest"]
     ]

--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -3,7 +3,7 @@
 --
 
 -- Dumped from database version 14.2 (Debian 14.2-1.pgdg110+1)
--- Dumped by pg_dump version 14.2 (Debian 14.2-1.pgdg110+1)
+-- Dumped by pg_dump version 14.5 (Debian 14.5-1.pgdg110+1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -21,7 +21,7 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
--- Name: channels; Type: TABLE; Schema: public; Owner: postgres
+-- Name: channels; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.channels (
@@ -35,10 +35,8 @@ CREATE TABLE public.channels (
 );
 
 
-ALTER TABLE public.channels OWNER TO postgres;
-
 --
--- Name: channels_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: channels_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.channels_id_seq
@@ -49,17 +47,15 @@ CREATE SEQUENCE public.channels_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.channels_id_seq OWNER TO postgres;
-
 --
--- Name: channels_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: channels_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.channels_id_seq OWNED BY public.channels.id;
 
 
 --
--- Name: clients; Type: TABLE; Schema: public; Owner: postgres
+-- Name: clients; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.clients (
@@ -70,10 +66,8 @@ CREATE TABLE public.clients (
 );
 
 
-ALTER TABLE public.clients OWNER TO postgres;
-
 --
--- Name: clients_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: clients_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.clients_id_seq
@@ -84,17 +78,15 @@ CREATE SEQUENCE public.clients_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.clients_id_seq OWNER TO postgres;
-
 --
--- Name: clients_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: clients_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.clients_id_seq OWNED BY public.clients.id;
 
 
 --
--- Name: notes; Type: TABLE; Schema: public; Owner: postgres
+-- Name: notes; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.notes (
@@ -108,10 +100,8 @@ CREATE TABLE public.notes (
 );
 
 
-ALTER TABLE public.notes OWNER TO postgres;
-
 --
--- Name: notes_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.notes_id_seq
@@ -122,17 +112,15 @@ CREATE SEQUENCE public.notes_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.notes_id_seq OWNER TO postgres;
-
 --
--- Name: notes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: notes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.notes_id_seq OWNED BY public.notes.id;
 
 
 --
--- Name: persistence_providers; Type: TABLE; Schema: public; Owner: postgres
+-- Name: persistence_providers; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.persistence_providers (
@@ -143,10 +131,8 @@ CREATE TABLE public.persistence_providers (
 );
 
 
-ALTER TABLE public.persistence_providers OWNER TO postgres;
-
 --
--- Name: persistence_providers_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: persistence_providers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.persistence_providers_id_seq
@@ -157,17 +143,15 @@ CREATE SEQUENCE public.persistence_providers_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.persistence_providers_id_seq OWNER TO postgres;
-
 --
--- Name: persistence_providers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: persistence_providers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.persistence_providers_id_seq OWNED BY public.persistence_providers.id;
 
 
 --
--- Name: project_providers; Type: TABLE; Schema: public; Owner: postgres
+-- Name: project_providers; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.project_providers (
@@ -180,10 +164,8 @@ CREATE TABLE public.project_providers (
 );
 
 
-ALTER TABLE public.project_providers OWNER TO postgres;
-
 --
--- Name: project_providers_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: project_providers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.project_providers_id_seq
@@ -194,17 +176,15 @@ CREATE SEQUENCE public.project_providers_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.project_providers_id_seq OWNER TO postgres;
-
 --
--- Name: project_providers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: project_providers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.project_providers_id_seq OWNED BY public.project_providers.id;
 
 
 --
--- Name: projects; Type: TABLE; Schema: public; Owner: postgres
+-- Name: projects; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.projects (
@@ -216,10 +196,8 @@ CREATE TABLE public.projects (
 );
 
 
-ALTER TABLE public.projects OWNER TO postgres;
-
 --
--- Name: projects_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: projects_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.projects_id_seq
@@ -230,17 +208,15 @@ CREATE SEQUENCE public.projects_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.projects_id_seq OWNER TO postgres;
-
 --
--- Name: projects_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: projects_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.projects_id_seq OWNED BY public.projects.id;
 
 
 --
--- Name: repositories; Type: TABLE; Schema: public; Owner: postgres
+-- Name: repositories; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.repositories (
@@ -256,10 +232,8 @@ CREATE TABLE public.repositories (
 );
 
 
-ALTER TABLE public.repositories OWNER TO postgres;
-
 --
--- Name: repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.repositories_id_seq
@@ -270,17 +244,15 @@ CREATE SEQUENCE public.repositories_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.repositories_id_seq OWNER TO postgres;
-
 --
--- Name: repositories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: repositories_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.repositories_id_seq OWNED BY public.repositories.id;
 
 
 --
--- Name: schema_migrations; Type: TABLE; Schema: public; Owner: postgres
+-- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.schema_migrations (
@@ -289,10 +261,8 @@ CREATE TABLE public.schema_migrations (
 );
 
 
-ALTER TABLE public.schema_migrations OWNER TO postgres;
-
 --
--- Name: tokens; Type: TABLE; Schema: public; Owner: postgres
+-- Name: tokens; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.tokens (
@@ -306,10 +276,8 @@ CREATE TABLE public.tokens (
 );
 
 
-ALTER TABLE public.tokens OWNER TO postgres;
-
 --
--- Name: tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.tokens_id_seq
@@ -320,17 +288,15 @@ CREATE SEQUENCE public.tokens_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.tokens_id_seq OWNER TO postgres;
-
 --
--- Name: tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.tokens_id_seq OWNED BY public.tokens.id;
 
 
 --
--- Name: users; Type: TABLE; Schema: public; Owner: postgres
+-- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.users (
@@ -343,10 +309,8 @@ CREATE TABLE public.users (
 );
 
 
-ALTER TABLE public.users OWNER TO postgres;
-
 --
--- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.users_id_seq
@@ -357,17 +321,15 @@ CREATE SEQUENCE public.users_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.users_id_seq OWNER TO postgres;
-
 --
--- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
--- Name: webhook_events; Type: TABLE; Schema: public; Owner: postgres
+-- Name: webhook_events; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public.webhook_events (
@@ -379,10 +341,8 @@ CREATE TABLE public.webhook_events (
 );
 
 
-ALTER TABLE public.webhook_events OWNER TO postgres;
-
 --
--- Name: webhook_events_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+-- Name: webhook_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
 CREATE SEQUENCE public.webhook_events_id_seq
@@ -393,87 +353,85 @@ CREATE SEQUENCE public.webhook_events_id_seq
     CACHE 1;
 
 
-ALTER TABLE public.webhook_events_id_seq OWNER TO postgres;
-
 --
--- Name: webhook_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+-- Name: webhook_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
 ALTER SEQUENCE public.webhook_events_id_seq OWNED BY public.webhook_events.id;
 
 
 --
--- Name: channels id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: channels id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.channels ALTER COLUMN id SET DEFAULT nextval('public.channels_id_seq'::regclass);
 
 
 --
--- Name: clients id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: clients id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.clients ALTER COLUMN id SET DEFAULT nextval('public.clients_id_seq'::regclass);
 
 
 --
--- Name: notes id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: notes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.notes ALTER COLUMN id SET DEFAULT nextval('public.notes_id_seq'::regclass);
 
 
 --
--- Name: persistence_providers id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: persistence_providers id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.persistence_providers ALTER COLUMN id SET DEFAULT nextval('public.persistence_providers_id_seq'::regclass);
 
 
 --
--- Name: project_providers id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: project_providers id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_providers ALTER COLUMN id SET DEFAULT nextval('public.project_providers_id_seq'::regclass);
 
 
 --
--- Name: projects id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: projects id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.projects ALTER COLUMN id SET DEFAULT nextval('public.projects_id_seq'::regclass);
 
 
 --
--- Name: repositories id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: repositories id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.repositories ALTER COLUMN id SET DEFAULT nextval('public.repositories_id_seq'::regclass);
 
 
 --
--- Name: tokens id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: tokens id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tokens ALTER COLUMN id SET DEFAULT nextval('public.tokens_id_seq'::regclass);
 
 
 --
--- Name: users id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
 
 
 --
--- Name: webhook_events id; Type: DEFAULT; Schema: public; Owner: postgres
+-- Name: webhook_events id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.webhook_events ALTER COLUMN id SET DEFAULT nextval('public.webhook_events_id_seq'::regclass);
 
 
 --
--- Name: channels channels_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: channels channels_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.channels
@@ -481,7 +439,7 @@ ALTER TABLE ONLY public.channels
 
 
 --
--- Name: clients clients_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: clients clients_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.clients
@@ -489,7 +447,7 @@ ALTER TABLE ONLY public.clients
 
 
 --
--- Name: notes notes_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: notes notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.notes
@@ -497,7 +455,7 @@ ALTER TABLE ONLY public.notes
 
 
 --
--- Name: persistence_providers persistence_providers_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: persistence_providers persistence_providers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.persistence_providers
@@ -505,7 +463,7 @@ ALTER TABLE ONLY public.persistence_providers
 
 
 --
--- Name: project_providers project_providers_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: project_providers project_providers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_providers
@@ -513,7 +471,7 @@ ALTER TABLE ONLY public.project_providers
 
 
 --
--- Name: projects projects_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: projects projects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.projects
@@ -521,7 +479,7 @@ ALTER TABLE ONLY public.projects
 
 
 --
--- Name: repositories repositories_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: repositories repositories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.repositories
@@ -529,7 +487,7 @@ ALTER TABLE ONLY public.repositories
 
 
 --
--- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.schema_migrations
@@ -537,7 +495,7 @@ ALTER TABLE ONLY public.schema_migrations
 
 
 --
--- Name: tokens tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: tokens tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tokens
@@ -545,7 +503,7 @@ ALTER TABLE ONLY public.tokens
 
 
 --
--- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.users
@@ -553,7 +511,7 @@ ALTER TABLE ONLY public.users
 
 
 --
--- Name: webhook_events webhook_events_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+-- Name: webhook_events webhook_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.webhook_events
@@ -561,7 +519,7 @@ ALTER TABLE ONLY public.webhook_events
 
 
 --
--- Name: channels channels_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: channels channels_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.channels
@@ -569,7 +527,7 @@ ALTER TABLE ONLY public.channels
 
 
 --
--- Name: channels channels_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: channels channels_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.channels
@@ -577,7 +535,7 @@ ALTER TABLE ONLY public.channels
 
 
 --
--- Name: notes notes_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: notes notes_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.notes
@@ -585,7 +543,7 @@ ALTER TABLE ONLY public.notes
 
 
 --
--- Name: project_providers project_providers_persistence_provider_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: project_providers project_providers_persistence_provider_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_providers
@@ -593,7 +551,7 @@ ALTER TABLE ONLY public.project_providers
 
 
 --
--- Name: project_providers project_providers_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: project_providers project_providers_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.project_providers
@@ -601,7 +559,7 @@ ALTER TABLE ONLY public.project_providers
 
 
 --
--- Name: projects projects_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: projects projects_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.projects
@@ -609,7 +567,7 @@ ALTER TABLE ONLY public.projects
 
 
 --
--- Name: repositories repositories_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: repositories repositories_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.repositories
@@ -617,7 +575,7 @@ ALTER TABLE ONLY public.repositories
 
 
 --
--- Name: tokens tokens_persistence_provider_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: tokens tokens_persistence_provider_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tokens
@@ -625,7 +583,7 @@ ALTER TABLE ONLY public.tokens
 
 
 --
--- Name: tokens tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: tokens tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.tokens
@@ -633,7 +591,7 @@ ALTER TABLE ONLY public.tokens
 
 
 --
--- Name: users users_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: users users_project_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.users
@@ -641,7 +599,7 @@ ALTER TABLE ONLY public.users
 
 
 --
--- Name: webhook_events webhook_events_repository_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: postgres
+-- Name: webhook_events webhook_events_repository_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.webhook_events
@@ -651,3 +609,15 @@ ALTER TABLE ONLY public.webhook_events
 --
 -- PostgreSQL database dump complete
 --
+
+INSERT INTO public."schema_migrations" (version) VALUES (20220523194246);
+INSERT INTO public."schema_migrations" (version) VALUES (20220523194247);
+INSERT INTO public."schema_migrations" (version) VALUES (20220523194248);
+INSERT INTO public."schema_migrations" (version) VALUES (20220613194248);
+INSERT INTO public."schema_migrations" (version) VALUES (20220613199248);
+INSERT INTO public."schema_migrations" (version) VALUES (20220614199250);
+INSERT INTO public."schema_migrations" (version) VALUES (20220825175612);
+INSERT INTO public."schema_migrations" (version) VALUES (20220825175641);
+INSERT INTO public."schema_migrations" (version) VALUES (20220902190835);
+INSERT INTO public."schema_migrations" (version) VALUES (20220902192328);
+INSERT INTO public."schema_migrations" (version) VALUES (20220922202207);

--- a/script/dump
+++ b/script/dump
@@ -1,0 +1,2 @@
+#/bin/bash
+docker-compose run app mix ecto.dump

--- a/script/migrate
+++ b/script/migrate
@@ -1,0 +1,2 @@
+#/bin/bash
+docker-compose run app mix db.migrate

--- a/script/rollback
+++ b/script/rollback
@@ -1,0 +1,2 @@
+#/bin/bash
+docker-compose run app mix db.rollback


### PR DESCRIPTION
Per [MRNN 62](https://mojotech.atlassian.net/jira/software/projects/MRNN/boards/22?selectedIssue=MRNN-62), this PR implements automated dumps when the new mix aliases are run. These aliases are able to be run using their respective scripts. Now that we have the the app dockerized, these new scripts are the easiest method for interacting with the database schema.

Postgres 14 needed to be added to the `app` docker-compose scaffold as `pg_dump` is a dependency for ecto.dump.