### PR TITLE
Automatically delete Confluence notes when deleted on Github

### DIFF
--- a/lib/release_notes_bot/persists.ex
+++ b/lib/release_notes_bot/persists.ex
@@ -90,50 +90,17 @@ defmodule ReleaseNotesBot.Persists do
   defp choose_action(sanitizer_changes, action, persistence_provider_id, page_info) do
     case action do
       "published" ->
-        case create(persistence_provider_id, sanitizer_changes) do
-          {:ok, endpoint} ->
-            {:ok, endpoint}
-
-          {:error, err} ->
-            {:error, err}
-        end
+        create(persistence_provider_id, sanitizer_changes)
 
       "edited" ->
-        case update(persistence_provider_id, sanitizer_changes, page_info) do
-          {:ok, res} ->
-            {:ok, res}
-
-          {:error, err} ->
-            {:error, err}
-        end
+        update(persistence_provider_id, sanitizer_changes, page_info)
 
       _ ->
         {:error, "Invalid action"}
     end
   end
 
-  defp create(persistence_provider_id, sanitizer_changes) do
-    case select_provider_to_persist(persistence_provider_id, sanitizer_changes) do
-      {:ok, endpoint} ->
-        {:ok, endpoint}
-
-      {:error, message} ->
-        {:error, message}
-    end
-  end
-
-  defp update(persistence_provider_id, sanitizer_changes, page_info)
-       when is_binary(page_info.slug) do
-    case select_provider_to_update(persistence_provider_id, sanitizer_changes, page_info) do
-      {:ok, endpoint} ->
-        {:ok, endpoint}
-
-      {:error, message} ->
-        {:error, message}
-    end
-  end
-
-  def select_provider_to_persist(persistence_provider_id, sanitizer_changes) do
+  def create(persistence_provider_id, sanitizer_changes) do
     case persistence_provider_id do
       # Confluence
       1 ->
@@ -150,7 +117,8 @@ defmodule ReleaseNotesBot.Persists do
     end
   end
 
-  def select_provider_to_update(persistence_provider_id, sanitizer_changes, page_info) do
+  def update(persistence_provider_id, sanitizer_changes, page_info)
+      when is_binary(page_info.slug) do
     case persistence_provider_id do
       # Confluence
       1 ->

--- a/lib/release_notes_bot/persists.ex
+++ b/lib/release_notes_bot/persists.ex
@@ -95,6 +95,9 @@ defmodule ReleaseNotesBot.Persists do
       "edited" ->
         update(persistence_provider_id, sanitizer_changes, page_info)
 
+      "deleted" ->
+        delete(persistence_provider_id, sanitizer_changes, page_info)
+
       _ ->
         {:error, "Invalid action"}
     end
@@ -123,6 +126,24 @@ defmodule ReleaseNotesBot.Persists do
       # Confluence
       1 ->
         case update_confluence_page(sanitizer_changes, page_info) do
+          {:ok, endpoint} ->
+            {:ok, endpoint}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      _ ->
+        {:error, "Invalid persistence provider"}
+    end
+  end
+
+  defp delete(persistence_provider_id, sanitizer_changes, page_info)
+       when is_binary(page_info.slug) do
+    case persistence_provider_id do
+      # Confluence
+      1 ->
+        case delete_confluence_page(sanitizer_changes, page_info) do
           {:ok, endpoint} ->
             {:ok, endpoint}
 
@@ -201,6 +222,25 @@ defmodule ReleaseNotesBot.Persists do
 
       {:error, _reason} ->
         {:error, "Finch request to update has failed"}
+    end
+  end
+
+  defp delete_confluence_page(data, page_info) do
+    headers = get_headers(%{"token" => data.token})
+
+    case Finch.request(
+           Finch.build(
+             :delete,
+             data.endpoint_persistence <> "/#{page_info.slug}",
+             headers
+           ),
+           ReleaseNotesBot.Finch
+         ) do
+      {:ok, _response} ->
+        {:ok, "Page deleted"}
+
+      {:error, _reason} ->
+        {:error, "Finch request to delete has failed"}
     end
   end
 

--- a/lib/release_notes_bot/project_providers.ex
+++ b/lib/release_notes_bot/project_providers.ex
@@ -11,6 +11,22 @@ defmodule ReleaseNotesBot.ProjectProviders do
     |> Repo.insert()
   end
 
+  def create_default(project_id) do
+    %ProjectProvider{}
+    |> ProjectProvider.changeset(%{
+      project_id: project_id,
+      persistence_provider_id: 1,
+      # TO DO: This should be able to be set by the user in the future
+      config: %{
+        "space_id" => Application.get_env(:release_notes_bot, :confluence_space_id),
+        "space_key" => Application.get_env(:release_notes_bot, :confluence_space_key),
+        "parent_id" => Application.get_env(:release_notes_bot, :confluence_parent_id),
+        "organization" => Application.get_env(:release_notes_bot, :confluence_organization)
+      }
+    })
+    |> Repo.insert()
+  end
+
   def get_all do
     Repo.all(ProjectProvider)
   end

--- a/lib/release_notes_bot/projects.ex
+++ b/lib/release_notes_bot/projects.ex
@@ -67,7 +67,7 @@ defmodule ReleaseNotesBot.Projects do
         new_project.id
       )
     else
-      ProjectProviders.create(%{"project_id" => new_project.id})
+      ProjectProviders.create_default(new_project.id)
     end
 
     github_repo_url =

--- a/lib/release_notes_bot/schema/webhook_event.ex
+++ b/lib/release_notes_bot/schema/webhook_event.ex
@@ -11,6 +11,7 @@ defmodule ReleaseNotesBot.Schema.WebhookEvent do
   schema "webhook_events" do
     field(:raw_payload, :map)
     belongs_to(:repository, ReleaseNotesBot.Schema.Repository)
+    has_many(:webhook_event_persistences, ReleaseNotesBot.Schema.WebhookEventPersistence)
 
     timestamps()
   end

--- a/lib/release_notes_bot/webhook_events.ex
+++ b/lib/release_notes_bot/webhook_events.ex
@@ -24,4 +24,18 @@ defmodule ReleaseNotesBot.WebhookEvents do
       create(%{:raw_payload => payload, :repository_id => repo_id})
     end)
   end
+
+  def update(webhook_event, params) do
+    webhook_event
+    |> WebhookEvent.changeset(params)
+    |> Repo.update()
+  end
+
+  def unpublish(webhook_event = %{:raw_payload => %{"action" => "published"}}) do
+    update(webhook_event, %{
+      :raw_payload => put_in(webhook_event.raw_payload, ["action"], "unpublished")
+    })
+  end
+
+  def unpublish(_webhook_event), do: nil
 end

--- a/lib/release_notes_bot_web/controllers/webhook_controller.ex
+++ b/lib/release_notes_bot_web/controllers/webhook_controller.ex
@@ -154,7 +154,7 @@ defmodule ReleaseNotesBotWeb.WebhookController do
       ) do
     case action do
       "deleted" ->
-        "Update for repository: #{repo["full_name"]}\n\n#{release["author"]["login"]} has #{action} the release on tag: #{release["tag_name"]}"
+        "#{release["author"]["login"]} has #{action} the release on tag: #{release["tag_name"]}"
 
       "edited" ->
         "#{release["author"]["login"]} has #{action} the published release on tag: #{release["tag_name"]}\n\n#{build_slack_url_embed(persistence, @view_on_persistence_message)}"


### PR DESCRIPTION
Per [Trello Ticket 67](https://mojotech.atlassian.net/jira/software/projects/MRNN/boards/22?selectedIssue=MRNN-67), delete notes on Confluence when they are removed on Github to enforce Github being a single-source-of-truth.