### PR TITLE
Send an error message upon Slack initialization in a direct message

### DIFF
--- a/lib/release_notes_bot/channels.ex
+++ b/lib/release_notes_bot/channels.ex
@@ -49,6 +49,14 @@ defmodule ReleaseNotesBot.Channels do
     |> Repo.preload([:client])
   end
 
+  def post_ephemeral(channel, message, target_user_id) do
+    Slack.Web.Chat.post_ephemeral(
+      channel,
+      message,
+      target_user_id
+    )
+  end
+
   def post_message(channel, message) do
     Slack.Web.Chat.post_message(
       channel,


### PR DESCRIPTION
Per [Jira Ticket 65](https://mojotech.atlassian.net/jira/software/projects/MRNN/boards/22?selectedIssue=MRNN-65), this PR shoots the user an error message when they try an initialize The Captain inside of a 1-person direct message. By design, Slack Bots are not permitted to send regular chat message inside of a 1 person dm. 